### PR TITLE
add buffer type and override escapeString function in parser.js

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -106,7 +106,7 @@ module.exports = class PostgreSQLParser extends Parser {
       }
     }
     if (helper.isBoolean(value)) return value ? 'true' : 'false';
-    if (helper.isBuffer(value)) return `\\x${value.toString('hex')}`;
+    if (helper.isBuffer(value)) return `'\\x${value.toString('hex')}'`;
     if (value === null) return 'null';
     return value;
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -106,6 +106,7 @@ module.exports = class PostgreSQLParser extends Parser {
       }
     }
     if (helper.isBoolean(value)) return value ? 'true' : 'false';
+    if (helper.isBuffer(value)) return `\\x${value.toString('hex')}`;
     if (value === null) return 'null';
     return value;
   }
@@ -117,5 +118,12 @@ module.exports = class PostgreSQLParser extends Parser {
     const sql = super.buildInsertSql(options);
     if (!options.pk) return sql;
     return `${sql} RETURNING ${options.pk}`;
+  }
+  /**
+   * escape string
+   * @param {String} str
+   */
+  escapeString(str) {
+    return str.replace(/'/g, "\\'");
   }
 };

--- a/test/parser.js
+++ b/test/parser.js
@@ -57,13 +57,15 @@ test('parseValue', t => {
   const parser = new Parser();
   const data = [
     ['lizheming', "E'lizheming'"],
+    ["I'm my wife's rock.", "E'I\\\'m my wife\\\'s rock.'"],
     [3, 3],
     [{ a: 1 }, { a: 1 }],
     [null, 'null'],
     [true, 'true'],
     [false, 'false'],
     [['EXP', '= 3'], '= 3'],
-    [[{ a: 1 }, 3, true, null, ['EXP', ' = 3']], [{ a: 1 }, 3, 'true', 'null', ' = 3']]
+    [[{ a: 1 }, 3, true, null, ['EXP', ' = 3']], [{ a: 1 }, 3, 'true', 'null', ' = 3']],
+    [new Buffer('abcdefg'), '\\x61626364656667']
   ];
 
   t.plan(data.length);

--- a/test/parser.js
+++ b/test/parser.js
@@ -65,7 +65,7 @@ test('parseValue', t => {
     [false, 'false'],
     [['EXP', '= 3'], '= 3'],
     [[{ a: 1 }, 3, true, null, ['EXP', ' = 3']], [{ a: 1 }, 3, 'true', 'null', ' = 3']],
-    [new Buffer('abcdefg'), '\\x61626364656667']
+    [Buffer.from('abcdefg'), "'\\x61626364656667'"]
   ];
 
   t.plan(data.length);


### PR DESCRIPTION
This PR includes bytea (A.K.A. Blob) type in PostgreSQL parsing supporting, and override the escapeString() function to escape single quotes as well.  
All changes have been passed the test.